### PR TITLE
Create FactionGlobalFiles.cs

### DIFF
--- a/EmpyrionScripting.Examples/FactionGlobalFiles.cs
+++ b/EmpyrionScripting.Examples/FactionGlobalFiles.cs
@@ -1,0 +1,46 @@
+using Eleon.Modding;
+using EmpyrionScripting;
+using EmpyrionScripting.CustomHelpers;
+using EmpyrionScripting.DataWrapper;
+using EmpyrionScripting.Interface;
+using System.Collections.Generic;
+using System.Linq;
+
+public class ModMain
+{
+    private static Dictionary<string, string> allfiles = new Dictionary<string, string>();
+    public static void Main(IScriptModData rootObject)
+    {
+        if (!(rootObject is IScriptSaveGameRootData root)) return;
+        if (root.E.Faction.Id == 0) return;
+        if (!root.Running) return;
+
+        var infoOutLcds = root.CsRoot.GetDevices<ILcd>(root.CsRoot.Devices(root.E.S, "FileIO"));
+
+        var writerLcds = root.CsRoot.GetDevices<ILcd>(root.CsRoot.Devices(root.E.S, "Write:*"));
+        writerLcds.ForEach(lcd => {
+          var filetag = lcd.CustomName.Split(':', 2)[1];
+          var filekey = $"{root.E.Faction.Id}:{filetag}";
+          files[filekey] = lcd.GetText();
+          WriteTo(infoOutLcds, $"{lcd.CustomName} saved.");
+        })
+
+        var readerLcds = root.CsRoot.GetDevices<ILcd>(root.CsRoot.Devices(root.E.S, "Read:*"));
+        readerLcds.ForEach(lcd => {
+          var filetag = lcd.CustomName.Split(':', 2)[1];
+          var filekey = $"{root.E.Faction.Id}:{filetag}";
+          string towrite = "";
+          if (files.TryGetValue(filekey, out towrite)) {
+            lcd.SetText(towrite);
+            WriteTo(infoOutLcds, $"{lcd.CustomName} loaded.");
+          } else {
+            WriteTo(infoOutLcds, $"{lcd.CustomName} not found.");
+          }
+        });
+    }
+
+    private static void WriteTo(ILcd[] lcds, string text)
+    {
+        lcds.ForEach(L => L.SetText($"{text}\n{L.GetText()}"));
+    }
+}


### PR DESCRIPTION
Just a totally untested (I don't have a setup to compile it), first stab at a suggestion for File/Message I/O.

On ship 1, anywhere in game, add an LCD named "Write:FromSixty". Set its text to "Hello!"

On ship 2, anywhere in game, add an LCD named "Read:FromSixty". Its text will be auto-set to the contents of above message.

On either ship, add an LCD named "FileIO" for debug information. This can get spammy.

This is limited to Factions. Factions can only see their own files. Over reboots, a Reader might blink, due to the Writer not being read yet.

Why add this?

- Combined with "CargoOut@*", this can allow scripters to add a request system. Add "AmmoName:10000" and if there's any in the base, base can push 10000 to CargoOut@(id)
- Collect Data from several ships and scripts into one location. Have ships write their statuses to Write: LCDs and collect them all with Read: LCDs.

Other possible ideas/changes to this code:
- Make it more like a semaphore. When a non-empty "Write:*" LCD is read, clear it. Then clear the file when it's "written" to a "Read:<tag>". Only write to a "Read:<tag>" if there's a value saved. So scripts can clear its text to wait for next writing